### PR TITLE
Replace deprecated np.int and np.float

### DIFF
--- a/igrf_utils.py
+++ b/igrf_utils.py
@@ -86,7 +86,7 @@ def load_shcfile(filepath, leap_year=None):
             read_line = np.fromstring(line, sep=' ')
             if read_line.size == 7:
                 name = os.path.split(filepath)[1]  # file name string
-                values = [name] + read_line.astype(np.int).tolist()
+                values = [name] + read_line.astype(int).tolist()
 
             else:
                 data = np.append(data, read_line)
@@ -392,10 +392,10 @@ def synth_values(coeffs, radius, theta, phi, \
     """
 
     # ensure ndarray inputs
-    coeffs = np.array(coeffs, dtype=np.float)
-    radius = np.array(radius, dtype=np.float) / 6371.2  # Earth's average radius
-    theta = np.array(theta, dtype=np.float)
-    phi = np.array(phi, dtype=np.float)
+    coeffs = np.array(coeffs, dtype=float)
+    radius = np.array(radius, dtype=float) / 6371.2  # Earth's average radius
+    theta = np.array(theta, dtype=float)
+    phi = np.array(phi, dtype=float)
 
     if np.amin(theta) <= 0.0 or np.amax(theta) >= 180.0:
         if np.amin(theta) == 0.0 or np.amax(theta) == 180.0:


### PR DESCRIPTION
Using python 3.12.3 and numpy 1.16.4.

Replaced two deprecated numpy calls with internals: `np.int` is now `int`; `np.float` is now `float`